### PR TITLE
UDP socket should bind to interface address instead of multicast address

### DIFF
--- a/ptp.js
+++ b/ptp.js
@@ -56,8 +56,8 @@ exports.init = function(interface, domain, callback){
 	ptp_domain = domain ? domain : 0;
 	cb = callback ? callback : function(){};
 
-	ptpClientEvent.bind(319, ptpMulticastAddrs[ptp_domain]);
-	ptpClientGeneral.bind(320, ptpMulticastAddrs[ptp_domain]);
+	ptpClientEvent.bind(319, addr);
+	ptpClientGeneral.bind(320, addr);
 }
 
 //event msg client


### PR DESCRIPTION
Hi!

Binding to the multicast address generates ``EADDRNOTAVAIL`` on my Windows machine. Changing this to the interface address solves this, and syncs correctly to the master.

For some reason this isn't a problem on my Linux box, but following the [Node documentation](https://nodejs.org/api/dgram.html#dgram_socket_bind_port_address_callback) it seems that this is the right way.

I stumbled upon this while using your aes67-sender, which I think is a really nice project.